### PR TITLE
Update gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,17 @@
+
+# Godot-specific ignores
 .import/
-**/*.import
+export.cfg
+export_presets.cfg
+
+# Imported translations (automatically generated from CSV files)
+*.translation
+
+# Mono-specific ignores
+.mono/
+data_*/
+mono_crash.*.json
+
+# System/tool-specific ignores
+.directory
+*~


### PR DESCRIPTION
The gitignore was missing a few things and was a bit outdated, so I updated it.

The `*.import` files store import settings and should not be ignored.